### PR TITLE
Flatten commands in simulator

### DIFF
--- a/src/core/simulator/execution-context.ts
+++ b/src/core/simulator/execution-context.ts
@@ -23,6 +23,12 @@ export class ExecutionContextState {
 }
 
 export class ExecutionContext extends ExecutionContextState {
+  private asyncEnabled = true;
+
+  setAsyncEnabled(enabled: boolean) {
+    this.asyncEnabled = enabled;
+  }
+
   pushCallStack(name: string, loc: SourceLocation) {
     this.callStack.push({ name, loc });
   }
@@ -56,7 +62,9 @@ export class ExecutionContext extends ExecutionContextState {
   }
 
   addWebApiTask(task: WebApiTask) {
-    this.webApi.push(task);
+    if (this.asyncEnabled) {
+      this.webApi.push(task);
+    }
   }
 
   removeWebApiTask(taskId: string) {


### PR DESCRIPTION
## Summary
- compute command order during `load` using a temporary `ExecutionContext`
- disable async handling for playback via `ExecutionContext.asyncEnabled`
- simplify `Simulator.step` to run commands sequentially

## Testing
- `yarn build` *(fails: project dependencies not installed)*
- `yarn lint` *(fails: project dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68497bfb9f48833293083493f33a2c33